### PR TITLE
Fixed orders sent to engine and listen to the right trades topic

### DIFF
--- a/consumer.js
+++ b/consumer.js
@@ -5,7 +5,7 @@ let client = new kafka.KafkaClient({kafkaHost: config.get("kafka.uri")});
 let consumer = new Consumer(
     client,
     [
-        { topic: 'engine.orders.btc.usd', partition: 0 }
+        { topic: 'engine.events.btc.usd', partition: 0 }
     ],
     {
         autoCommit: true,

--- a/producer.js
+++ b/producer.js
@@ -72,8 +72,8 @@ let Producer = kafka.Producer,
     client = new kafka.KafkaClient({kafkaHost: config.get("kafka.uri")})
     producer = new Producer(client),
     payloads = [
-        { topic: 'engine.orders.btc.usd', messages: buyOrders, partition: 0 },
-        { topic: 'engine.orders.btc.usd', messages: sellOrders, partition: 0 },
+        { topic: 'engine.orders.btc.usd', messages: buyOrders.map(order => JSON.stringify(order)), partition: 0 },
+        { topic: 'engine.orders.btc.usd', messages: sellOrders.map(order => JSON.stringify(order)), partition: 0 },
     ];
 
 producer.on('ready', function () {


### PR DESCRIPTION
The orders need to be serialised as JSON encoded strings before they are sent to Kafka, otherwise they will be converted automatically to strings as "Object()" and the engine will not know how to process them.

I've also modified the consumer to listen to engine.events.btc.usd topic instead of the one for orders and it does return a trade back with this message:
```js
{ topic: 'engine.events.btc.usd',
  value: '{"taker_order_id":"order-06","maker_order_id":"order-02","price":"5610.00000000","amount":"0.33000000"}',
  offset: 0,
  partition: 0,
  highWaterOffset: 1,
  key: null }
```